### PR TITLE
Update cJSON.c

### DIFF
--- a/libs/cjson/src/cJSON.c
+++ b/libs/cjson/src/cJSON.c
@@ -298,6 +298,7 @@ static cJSON_bool parse_number(cJSON * const item, parse_buffer * const input_bu
      * This also takes care of '\0' not necessarily being available for marking the end of the input */
     for (i = 0; (i < (sizeof(number_c_string) - 1)) && can_access_at_index(input_buffer, i); i++)
     {
+        after_end ++; // count the number of character to set buffer.offset for the next item
         switch (buffer_at_offset(input_buffer)[i])
         {
             case '0':
@@ -327,11 +328,14 @@ static cJSON_bool parse_number(cJSON * const item, parse_buffer * const input_bu
     }
 loop_end:
     number_c_string[i] = '\0';
-#ifdef GPRS_CSDK
+//sinse we are using the GPRS_SDK anyways the following check is disabled and the first condition is copied out
+/*#ifdef GPRS_CSDK
     number = atof((const char*)number_c_string);
 #else
     number = strtod((const char*)number_c_string, (char**)&after_end);
-#endif
+#endif*/
+
+    number = atof((const char*)number_c_string);
     if (number_c_string == after_end)
     {
         return false; /* parse_error */
@@ -354,8 +358,9 @@ loop_end:
     }
 
     item->type = cJSON_Number;
-
-    input_buffer->offset += (size_t)(after_end - number_c_string);
+    after_end--; //step back one character to get the coma marker
+    input_buffer->offset += (size_t)after_end; // set next point
+    //input_buffer->offset += (size_t)(after_end - number_c_string);// this line causes an over flow because after_end oreginaly is equalto NULL
     return true;
 }
 


### PR DESCRIPTION
originaly if a JSON with numbers in it ex.: {\"int\":123,\"D\":1.23} is passed to the cJSON_parse() function it would return a NULL cJSON object, that is because the original cJSON.c uses the function strtod() function of the stdlib.c file, while the original strtod() returns a pointer (after_end) to the created double last digit, the GPRS_CSDK doesn't use this function instead it uses atof() which doesn't return a pointer causing cJSON to be unable de determine where the next JSON object starts, and in return it gives back a NULL JSON bject, my work around is just a way to populate the pointer (after_end) with the number of digits, in order for cJSON to be able to find the next JSON object.